### PR TITLE
Allow reference results for alias symbols.

### DIFF
--- a/src/lsif.ts
+++ b/src/lsif.ts
@@ -716,10 +716,6 @@ class AliasedSymbolData extends StandardSymbolData {
       .getOrCreatePartition(sourceFile)
       .addReference(reference as any, property as any)
   }
-
-  public getOrCreateReferenceResult(): ReferenceResult {
-    throw new Error(`Shouldn't be called`)
-  }
 }
 
 class MethodSymbolData extends StandardSymbolData {


### PR DESCRIPTION
Closes #2.

There doesn't seem to be a downside to allowing reference results for alias symbols. This stops kibana and moment from crashing during the indexing step.