### PR TITLE
Update to TypeScript 3.8.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "lsif-protocol": "0.4.3",
     "minimist": "^1.2.0",
     "npm": "^6.14.2",
-    "typescript-lsif": "https://github.com/dbaeumer/TypeScript/releases/download/release%2Flisf%2F3.5.2/typescript-3.5.2-lsif.tgz",
+    "typescript-lsif": "https://github.com/dbaeumer/TypeScript/releases/download/3.8.3-lsif/typescript-3.8.3-lsif.tgz",
     "uuid": "^7.0.2",
     "vscode-uri": "^2.1.1"
   },

--- a/src/lsif.ts
+++ b/src/lsif.ts
@@ -2220,18 +2220,26 @@ class Visitor implements ResolverContext {
         sourceFileSymbol !== undefined
       ) {
         if (node.exportClause !== undefined) {
-          for (let element of node.exportClause.elements) {
+          function isNamedExports(bindings: ts.NamedExportBindings): bindings is ts.NamedExports {
+            return 'elements' in bindings
+          }
+
+          const elements = isNamedExports(node.exportClause)
+            ? node.exportClause.elements
+            : [{ name: node.exportClause.name, propertyName: undefined }]
+
+          for (let {name, propertyName} of elements) {
             let exportSymbol = this.typeChecker.getSymbolAtLocation(
-              element.name
+              name
             )
             if (exportSymbol === undefined) {
               continue
             }
             processSymbol(disposables, sourceFileSymbol, exportSymbol)
             let localSymbol: ts.Symbol | undefined
-            if (element.propertyName !== undefined) {
+            if (propertyName !== undefined) {
               localSymbol = this.typeChecker.getSymbolAtLocation(
-                element.propertyName
+                propertyName
               )
             } else if (tss.isAliasSymbol(exportSymbol)) {
               localSymbol = this.typeChecker.getAliasedSymbol(exportSymbol)

--- a/src/typescripts.ts
+++ b/src/typescripts.ts
@@ -139,7 +139,7 @@ export function flattenDiagnosticMessageText(
   while (diagnosticChains.length > 0) {
     const diagnosticChain = diagnosticChains.shift()
 
-    while (diagnosticChain){
+    if (diagnosticChain) {
       if (indent) {
         result += newLine
 

--- a/src/typescripts.ts
+++ b/src/typescripts.ts
@@ -131,11 +131,14 @@ export function flattenDiagnosticMessageText(
   if (Is.string(messageText)) {
     return messageText
   } else {
-    let diagnosticChain = messageText
+    let diagnosticChains = [messageText]
     let result = ''
 
     let indent = 0
-    while (diagnosticChain) {
+    while (diagnosticChains.length > 0) {
+    const diagnosticChain = diagnosticChains.shift()
+
+    while (diagnosticChain){
       if (indent) {
         result += newLine
 
@@ -145,7 +148,8 @@ export function flattenDiagnosticMessageText(
       }
       result += diagnosticChain.messageText
       indent++
-      diagnosticChain = diagnosticChain.next
+      diagnosticChains = diagnosticChains.concat(diagnosticChain.next)
+    }
     }
     return result
   }

--- a/src/typescripts.ts
+++ b/src/typescripts.ts
@@ -130,12 +130,13 @@ export function flattenDiagnosticMessageText(
 ): string {
   if (Is.string(messageText)) {
     return messageText
-  } else {
-    let diagnosticChains = [messageText]
-    let result = ''
+  }
 
-    let indent = 0
-    while (diagnosticChains.length > 0) {
+  let diagnosticChains = [messageText]
+  let result = ''
+
+  let indent = 0
+  while (diagnosticChains.length > 0) {
     const diagnosticChain = diagnosticChains.shift()
 
     while (diagnosticChain){
@@ -150,9 +151,8 @@ export function flattenDiagnosticMessageText(
       indent++
       diagnosticChains = diagnosticChains.concat(diagnosticChain.next)
     }
-    }
-    return result
   }
+  return result
 }
 
 interface InternalSymbol extends ts.Symbol {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2635,7 +2635,6 @@ npm@^6.14.2:
     cmd-shim "^3.0.3"
     columnify "~1.5.4"
     config-chain "^1.1.12"
-    debuglog "*"
     detect-indent "~5.0.0"
     detect-newline "^2.1.0"
     dezalgo "~1.0.3"
@@ -2650,7 +2649,6 @@ npm@^6.14.2:
     has-unicode "~2.0.1"
     hosted-git-info "^2.8.8"
     iferr "^1.0.2"
-    imurmurhash "*"
     infer-owner "^1.0.4"
     inflight "~1.0.6"
     inherits "^2.0.4"
@@ -2669,14 +2667,8 @@ npm@^6.14.2:
     libnpx "^10.2.2"
     lock-verify "^2.1.0"
     lockfile "^1.0.4"
-    lodash._baseindexof "*"
     lodash._baseuniq "~4.6.0"
-    lodash._bindcallback "*"
-    lodash._cacheindexof "*"
-    lodash._createcache "*"
-    lodash._getnative "*"
     lodash.clonedeep "~4.5.0"
-    lodash.restparam "*"
     lodash.union "~4.6.0"
     lodash.uniq "~4.5.0"
     lodash.without "~4.4.0"
@@ -4029,9 +4021,9 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-"typescript-lsif@https://github.com/dbaeumer/TypeScript/releases/download/release%2Flisf%2F3.5.2/typescript-3.5.2-lsif.tgz":
-  version "3.5.2-lsif"
-  resolved "https://github.com/dbaeumer/TypeScript/releases/download/release%2Flisf%2F3.5.2/typescript-3.5.2-lsif.tgz#8929a92f50fdeab086e6da0f1a44adfca82a4e5f"
+"typescript-lsif@https://github.com/dbaeumer/TypeScript/releases/download/3.8.3-lsif/typescript-3.8.3-lsif.tgz":
+  version "3.8.3-lsif"
+  resolved "https://github.com/dbaeumer/TypeScript/releases/download/3.8.3-lsif/typescript-3.8.3-lsif.tgz#25e41758f6b5766b9bfa7ea44cbb367117e9768f"
 
 typescript@^3.8.3:
   version "3.8.3"


### PR DESCRIPTION
We originally forked this repo from Microsoft's LSIF node indexer, which made use of a special LSIF-specific version of TypeScript that contains some additional methods on ast and diagnostic interfaces. The branch is maintained on a fork in https://github.com/dbaeumer/TypeScript.

This was pinned at ~3.5 and has recently been updated to merge the changes from 3.8.3. There are a few breaking changes.

In order to see what changed, clone the fork above and compare the revhashes:

- 094b236a15a93c0fd89590ecc662af1499c5a0e1
- 590f9a4fa0e07f6c8e01d51463bea76c70a1b736

This will show all of the protocol differences in tsc between the two LSIF releases.