### PR TITLE
Bump release node version to 14

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
         uses: docker/setup-buildx-action@v1
       - uses: actions/setup-node@v2
         with:
-          node-version: 13
+          node-version: 14
           registry-url: 'https://registry.npmjs.org'
       - run: yarn install
       - run: yarn run build


### PR DESCRIPTION
> error eslint-utils@3.0.0: The engine "node" is incompatible with this module. Expected version "^10.0.0 || ^12.0.0 || >= 14.0.0". Got "13.14.0"

https://github.com/sourcegraph/lsif-node/runs/3114797822?check_suite_focus=true

:shrug:
